### PR TITLE
Change cache parent

### DIFF
--- a/src/LightningBolt.lua
+++ b/src/LightningBolt.lua
@@ -9,7 +9,7 @@
 local PARTS_IN_CACHE = 1000 --Recommend setting higher if you intend to use LightningSparks
 local clock = os.clock
 local workspace, RunService = game:GetService("Workspace"), game:GetService("RunService")
-local parent = workspace.CurrentCamera
+local parent = workspace.Terrain
 
 --*Part Cache Setup
 --New parts automatically get added to cache if more parts are requested for use where a warning is thrown


### PR DESCRIPTION
During my testing when the Cache parent is set to the CurrentCamera the CurrentCamera would randomly change while in studio between causing the old camera to be parented to nil and thus the parts can't be seen this just changes the parent to Terrain an instance that can't be removed

sorry if I over explained this was a pretty much invisible and confused me for a while as when the cache made new parts they would be parented to the correct Camera

TLDR; Use Terrain as the cache's parent as Terrain can't be removed